### PR TITLE
Fix long to string conversion preventing build with JDK 17

### DIFF
--- a/src/main/java/fr/clementgre/pdf4teachers/interfaces/windows/AboutWindow.java
+++ b/src/main/java/fr/clementgre/pdf4teachers/interfaces/windows/AboutWindow.java
@@ -100,7 +100,7 @@ public class AboutWindow extends Stage {
 
         liscenselabel.setText(TR.tr("aboutWindow.info.license", "Apache 2"));
 
-        statsLabel.setText(TR.tr("aboutWindow.statistics", MainWindow.twoDigFormat.format(MainWindow.userData.foregroundTime/61d), (String) MainWindow.userData.startsCount));
+        statsLabel.setText(TR.tr("aboutWindow.statistics", MainWindow.twoDigFormat.format(MainWindow.userData.foregroundTime/61d), String.valueOf(MainWindow.userData.startsCount)));
         statsLabel.setWrapText(true);
         statsLabel.setTextAlignment(TextAlignment.CENTER);
     }


### PR DESCRIPTION
Would fix https://github.com/ClementGre/PDF4Teachers/issues/68 unless it's incompatible with previous Java versions