### PR TITLE
Fix the bug that the computer language is not 'en' 'fr' or 'it'

### DIFF
--- a/src/main/java/fr/clementgre/pdf4teachers/interfaces/windows/language/LanguageWindow.java
+++ b/src/main/java/fr/clementgre/pdf4teachers/interfaces/windows/language/LanguageWindow.java
@@ -46,8 +46,6 @@ public class LanguageWindow extends AlternativeWindow<ListView<LanguagePane>> {
     public LanguageWindow(CallBackArg<String> callBack){
         super(new ListView<>(), StageWidth.NORMAL, TR.tr("language.chooseLanguageWindow.title"), TR.tr("language.chooseLanguageWindow.title"));
         this.callBack = callBack;
-        
-        if(Main.settings.language.getValue().isEmpty()) Main.settings.language.setValue("en_us");
     }
     
     @Override


### PR DESCRIPTION
I have identified the problem and it is indeed a bug.

When user first installs and runs PDF4Teachers, and user's computer language is not `en` `fr` and `it`, the PDF4Teachers will run a language selection window for the user to select the target language, and its execution path is as follows:

> Main.Main ->Main.setup ->Main.languageAsk ->LanguageWindow.showLanguageWindow ->LanguagesUpdater.update ->
LanguagesUpdater.complete ->LanguageWindow.LanguageWindow ->callBack(selectedLanguage)

The problem arises in `LanguageWindow.LanguageWindow` function, the code for this function is as follows:
```Java
public LanguageWindow(CallBackArg<String> callBack){
        super(new ListView<>(), StageWidth.NORMAL, TR.tr("language.chooseLanguageWindow.title"), TR.tr("language.chooseLanguageWindow.title"));
        this.callBack = callBack;
        
        if(Main.settings.language.getValue().isEmpty()) Main.settings.language.setValue("en_us");
    }
```
In `LanguageWindow`, the value of `Main.settings.language` will be checked, and if the value is empty, it will be set to `en_us` Afterwards, the `callBack (selectedLanguage)` is excuted, and the `callBack (selectedLanguage)` function code is as follows:
```Java
new LanguageWindow(selectedLanguage -> {
                if(!selectedLanguage.isEmpty() && !selectedLanguage.equals(Main.settings.language.getValue())){
                    String oldDocPath = TR.getDocFile().getAbsolutePath();
        
                    Main.settings.language.setValue(selectedLanguage);
                    Main.settings.saveSettings();
        
                    if(!firstStartBehaviour){
                        Main.window.restart(true, oldDocPath);
                    }else{
                        TR.updateLocale();
                        Main.startMainWindowAuto();
                    }
                }
            });
```
If the language chosen by the user is `fr` or `it`, the codes in the `if-condition` can be executed normally. However, if the language chosen by the user is `en`, the condition `selectedLanguage.equals (Main.settings.language.getValue ())` is True, causing the `if-statement` cannot be executed. However, there is no corresponding code to handle this situation, resulting in PDF4Teachers exceptions.

In summary, the condition for this bug to occur is that the user's computer language is not `en` `fr` and `it`, and selecting `en_us` as the target language when running PDF4Teacher for the first time. Selecting `fr` and `it` as the target language will not cause the bug to appear.

The solution is to remove the code that sets `Main.settings.language` in `LanguageWindow.LanguageWindow` function. The following is modified codes:
```java
public LanguageWindow(CallBackArg<String> callBack){
        super(new ListView<>(), StageWidth.NORMAL, TR.tr("language.chooseLanguageWindow.title"), TR.tr("language.chooseLanguageWindow.title"));
        this.callBack = callBack;
    }
```

_Originally posted by @Clinale in https://github.com/ClementGre/PDF4Teachers/issues/177#issuecomment-1864076429_
            