### PR TITLE
refactor: replace size checks with isEmpty()

### DIFF
--- a/src/main/java/fr/clementgre/pdf4teachers/document/editions/Edition.java
+++ b/src/main/java/fr/clementgre/pdf4teachers/document/editions/Edition.java
@@ -191,7 +191,7 @@ public class Edition{
                 .filter(acceptedElements::isInstance)
                 .map(Element::getYAMLData)
                 .collect(Collectors.toCollection(ArrayList::new));
-        if(pageData.size() >= 1) return pageData;
+        if(!pageData.isEmpty()) return pageData;
         else return null;
     }
     

--- a/src/main/java/fr/clementgre/pdf4teachers/panel/sidebar/grades/GradeCopyGradeScaleDialog.java
+++ b/src/main/java/fr/clementgre/pdf4teachers/panel/sidebar/grades/GradeCopyGradeScaleDialog.java
@@ -101,7 +101,7 @@ public class GradeCopyGradeScaleDialog {
                 else otherElements.add(element);
             }
             
-            if(gradeElements.size() >= 1 && !ignoreAlreadyExist){
+            if(!gradeElements.isEmpty() && !ignoreAlreadyExist){
                 CustomAlert alert = new CustomAlert(Alert.AlertType.WARNING, TR.tr("gradeTab.copyGradeScaleDialog.error.alreadyGradeScale.title"),
                         TR.tr("gradeTab.copyGradeScaleDialog.error.alreadyGradeScale.header", file.getName()), TR.tr("gradeTab.copyGradeScaleDialog.error.alreadyGradeScale.details"));
                 
@@ -138,7 +138,7 @@ public class GradeCopyGradeScaleDialog {
                 }
             }
             
-            if(gradeElements.size() >= 1 && !ignoreErase){
+            if(!gradeElements.isEmpty() && !ignoreErase){
                 String grades = "";
                 for(GradeElement grade : gradeElements){
                     grades += "\n" + grade.getParentPath().replaceAll(Pattern.quote("\\"), "/") + "/" + grade.getName() + "  (" + MainWindow.gradesDigFormat.format(grade.getValue()).replaceAll("-1", "?") + "/" + MainWindow.gradesDigFormat.format(grade.getTotal()) + ")";

--- a/src/main/java/fr/clementgre/pdf4teachers/panel/sidebar/grades/GradeTab.java
+++ b/src/main/java/fr/clementgre/pdf4teachers/panel/sidebar/grades/GradeTab.java
@@ -89,7 +89,7 @@ public class GradeTab extends SideTab {
         MainWindow.mainScreen.setSelected(null);
         
         String name = TR.tr("gradeTab.gradeDefaultName");
-        if(parent.getChildren().size() >= 1){
+        if(!parent.getChildren().isEmpty()){
             String lastName = ((GradeTreeItem) parent.getChildren().get(parent.getChildren().size() - 1)).getCore().getName();
             String newName = StringUtils.incrementName(lastName);
             if(!lastName.equals(newName)) name = newName;

--- a/src/main/java/fr/clementgre/pdf4teachers/panel/sidebar/grades/export/GradeExportRenderer.java
+++ b/src/main/java/fr/clementgre/pdf4teachers/panel/sidebar/grades/export/GradeExportRenderer.java
@@ -188,7 +188,7 @@ public class GradeExportRenderer {
         
         content += TR.tr("gradeTab.gradeExportWindow.csv.titles.comments");
         
-        if(file.comments.size() >= 1){
+        if(!file.comments.isEmpty()){
             
             // Sort text elements (top to bottom)
             file.comments.sort((e1, e2) -> e2.compareTo(e1));

--- a/src/main/java/fr/clementgre/pdf4teachers/panel/sidebar/texts/ListsManager.java
+++ b/src/main/java/fr/clementgre/pdf4teachers/panel/sidebar/texts/ListsManager.java
@@ -86,7 +86,7 @@ public class ListsManager {
         //menu.setMinWidth(400);
         //menu.setPrefWidth(400);
         
-        if(TextTreeSection.lists.size() >= 1){
+        if(!TextTreeSection.lists.isEmpty()){
             for(Map.Entry<String, ArrayList<TextListItem>> list : TextTreeSection.lists.entrySet()){
                 NodeMenuItem menuItem = new NodeMenuItem(list.getKey(), false);
                 loadListBtn.getItems().add(menuItem);


### PR DESCRIPTION
Refactor conditional statements across various classes to use `isEmpty()` instead of size checks for better readability and performance.

- Changed `Edition.java` to use `isEmpty()` for checking `pageData`.
- Changed `GradeCopyGradeScaleDialog.java` to use `isEmpty()` for `gradeElements`.
- Changed `GradeTab.java` to use `isEmpty()` for checking `parent.getChildren()`.
- Changed `GradeExportRenderer.java` to use `isEmpty()` for `file.comments`.
- Changed `ListsManager.java` to use `isEmpty()` for `TextTreeSection.lists`.