### PR TITLE
refactor: replace string concatenation with StringBuilder for efficiency

### DIFF
--- a/src/main/java/fr/clementgre/pdf4teachers/interfaces/windows/splitpdf/SplitEngine.java
+++ b/src/main/java/fr/clementgre/pdf4teachers/interfaces/windows/splitpdf/SplitEngine.java
@@ -53,17 +53,24 @@ public class SplitEngine {
         AlreadyExistDialogManager alreadyExistDialogManager = new AlreadyExistDialogManager(recursive);
         new TwoStepListAction<>(true, recursive, new TwoStepListInterface<ExportPart, ExportPart>() {
             @Override
-            public List<ExportPart> prepare(boolean recursive){
+            public List<ExportPart> prepare(boolean recursive) {
+                List<ExportPart> exportParts = new ArrayList<>();
                 
-                ArrayList<ExportPart> exportParts = new ArrayList<>();
-                for(int i = 0; i < sectionsBounds.size(); i+=2){
-                    String path = out.getAbsolutePath() + File.separator + splitWindow.getNames()[i/2];
-                    if(!path.toLowerCase().endsWith(".pdf")) path += ".pdf";
+                for(int i = 0; i < sectionsBounds.size(); i += 2) {
+                    StringBuilder pathBuilder = new StringBuilder()
+                            .append(out.getAbsolutePath())
+                            .append(File.separator)
+                            .append(splitWindow.getNames()[i / 2]);
                     
-                    exportParts.add(new ExportPart(new File(path), sectionsBounds.get(i), sectionsBounds.get(i+1)));
+                    if(!pathBuilder.toString().toLowerCase().endsWith(".pdf")) pathBuilder.append(".pdf");
+                    
+                    String path = pathBuilder.toString();
+                    exportParts.add(new ExportPart(new File(path), sectionsBounds.get(i), sectionsBounds.get(i + 1)));
                 }
+                
                 return exportParts;
             }
+
         
             @Override
             public Map.Entry<ExportPart, Integer> filterData(ExportPart exportPart, boolean recursive){

--- a/src/main/java/fr/clementgre/pdf4teachers/interfaces/windows/splitpdf/SplitEngine.java
+++ b/src/main/java/fr/clementgre/pdf4teachers/interfaces/windows/splitpdf/SplitEngine.java
@@ -53,24 +53,17 @@ public class SplitEngine {
         AlreadyExistDialogManager alreadyExistDialogManager = new AlreadyExistDialogManager(recursive);
         new TwoStepListAction<>(true, recursive, new TwoStepListInterface<ExportPart, ExportPart>() {
             @Override
-            public List<ExportPart> prepare(boolean recursive) {
-                List<ExportPart> exportParts = new ArrayList<>();
+            public List<ExportPart> prepare(boolean recursive){
                 
-                for(int i = 0; i < sectionsBounds.size(); i += 2) {
-                    StringBuilder pathBuilder = new StringBuilder()
-                            .append(out.getAbsolutePath())
-                            .append(File.separator)
-                            .append(splitWindow.getNames()[i / 2]);
+                ArrayList<ExportPart> exportParts = new ArrayList<>();
+                for(int i = 0; i < sectionsBounds.size(); i+=2){
+                    String path = out.getAbsolutePath() + File.separator + splitWindow.getNames()[i/2];
+                    if(!path.toLowerCase().endsWith(".pdf")) path += ".pdf";
                     
-                    if(!pathBuilder.toString().toLowerCase().endsWith(".pdf")) pathBuilder.append(".pdf");
-                    
-                    String path = pathBuilder.toString();
-                    exportParts.add(new ExportPart(new File(path), sectionsBounds.get(i), sectionsBounds.get(i + 1)));
+                    exportParts.add(new ExportPart(new File(path), sectionsBounds.get(i), sectionsBounds.get(i+1)));
                 }
-                
                 return exportParts;
             }
-
         
             @Override
             public Map.Entry<ExportPart, Integer> filterData(ExportPart exportPart, boolean recursive){

--- a/src/main/java/fr/clementgre/pdf4teachers/panel/sidebar/grades/GradeCopyGradeScaleDialog.java
+++ b/src/main/java/fr/clementgre/pdf4teachers/panel/sidebar/grades/GradeCopyGradeScaleDialog.java
@@ -139,13 +139,13 @@ public class GradeCopyGradeScaleDialog {
             }
             
             if(!gradeElements.isEmpty() && !ignoreErase){
-                String grades = "";
+                StringBuilder grades = new StringBuilder();
                 for(GradeElement grade : gradeElements){
-                    grades += "\n" + grade.getParentPath().replaceAll(Pattern.quote("\\"), "/") + "/" + grade.getName() + "  (" + MainWindow.gradesDigFormat.format(grade.getValue()).replaceAll("-1", "?") + "/" + MainWindow.gradesDigFormat.format(grade.getTotal()) + ")";
+                    grades.append("\n").append(grade.getParentPath().replaceAll(Pattern.quote("\\"), "/")).append("/").append(grade.getName()).append("  (").append(MainWindow.gradesDigFormat.format(grade.getValue()).replaceAll("-1", "?")).append("/").append(MainWindow.gradesDigFormat.format(grade.getTotal())).append(")");
                 }
                 
                 CustomAlert alert = new CustomAlert(Alert.AlertType.WARNING, TR.tr("gradeTab.copyGradeScaleDialog.error.alreadyGradeScaleErase.title"),
-                        TR.tr("gradeTab.copyGradeScaleDialog.error.alreadyGradeScaleErase.header", grades, file.getName()));
+                        TR.tr("gradeTab.copyGradeScaleDialog.error.alreadyGradeScaleErase.header", grades.toString(), file.getName()));
                 
                 ButtonType ignore = alert.getButton(TR.tr("dialog.actionError.overwrite"), ButtonPosition.DEFAULT);
                 ButtonType ignoreAll = alert.getButton(TR.tr("dialog.actionError.overwriteAlways"), ButtonPosition.OTHER_RIGHT);

--- a/src/main/java/fr/clementgre/pdf4teachers/panel/sidebar/grades/export/GradeExportRenderer.java
+++ b/src/main/java/fr/clementgre/pdf4teachers/panel/sidebar/grades/export/GradeExportRenderer.java
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 
 public class GradeExportRenderer {
     
-    private String content = "";
+    private StringBuilder content = new StringBuilder();
     
     private ArrayList<GradeRating> gradeScale;
     private final ArrayList<ExportFile> files = new ArrayList<>();
@@ -113,29 +113,29 @@ public class GradeExportRenderer {
     
     public void generateNamesLine(boolean includeGradeScale){
         
-        content += TR.tr("gradeTab.gradeExportWindow.csv.titles.parts");
+        content.append(TR.tr("gradeTab.gradeExportWindow.csv.titles.parts"));
         
         for(GradeRating rating : gradeScale){
             if(rating.isRoot() && rating.outOfTotal > 0){
-                if(includeGradeScale) content += separator + rating.name + " /" + decimalFormat.format(rating.outOfTotal);
-                else content += separator + rating.name + " (/" + decimalFormat.format(rating.outOfTotal) + ")";
+                if(includeGradeScale) content.append(separator).append(rating.name).append(" /").append(decimalFormat.format(rating.outOfTotal));
+                else content.append(separator).append(rating.name).append(" (/").append(decimalFormat.format(rating.outOfTotal)).append(")");
             }
-            content += separator + rating.name + (includeGradeScale ? " /" + decimalFormat.format(rating.total) : "");
+            content.append(separator).append(rating.name).append(includeGradeScale ? " /" + decimalFormat.format(rating.total) : "");
         }
-        content += "\n";
+        content.append("\n");
     }
     
     public void generateGradeScaleLine(){
         
-        content += TR.tr("gradeTab.gradeExportWindow.csv.titles.gradeScale");
+        content.append(TR.tr("gradeTab.gradeExportWindow.csv.titles.gradeScale"));
         
         for(GradeRating rating : gradeScale){
             if(rating.isRoot() && rating.outOfTotal > 0){
-                content += separator + decimalFormat.format(rating.outOfTotal);
+                content.append(separator).append(decimalFormat.format(rating.outOfTotal));
             }
-            content += separator + decimalFormat.format(rating.total);
+            content.append(separator).append(decimalFormat.format(rating.total));
         }
-        content += "\n";
+        content.append("\n");
         
     }
     
@@ -145,38 +145,38 @@ public class GradeExportRenderer {
         int startY = pane.settingsAttributeTotalLine.isSelected() ? 4 : 3;
         int endY = startY + files.size() - 1;
         
-        content += TR.tr("gradeTab.gradeExportWindow.csv.titles.average");
+        content.append(TR.tr("gradeTab.gradeExportWindow.csv.titles.average"));
         
         for(GradeRating rating : gradeScale){
             String formula = pane.settingsCSVFormulaEnglish.isSelected() ? "AVERAGE" : TR.tr("gradeTab.gradeExportWindow.csv.formulas.average.name").toUpperCase();
             if(rating.isRoot() && rating.outOfTotal > 0){
-                content += separator + "=" + formula + "(" + x + startY + ":" + x + endY + ")";
+                content.append(separator).append("=").append(formula).append("(").append(x).append(startY).append(":").append(x).append(endY).append(")");
                 x++;
             }
-            content += separator + "=" + formula + "(" + x + startY + ":" + x + endY + ")";
+            content.append(separator).append("=").append(formula).append("(").append(x).append(startY).append(":").append(x).append(endY).append(")");
             x++;
         }
-        content += "\n";
+        content.append("\n");
     }
     
     public void generateStudentLine(ExportFile file){
         
         if(pane.studentNameSimple != null){
-            content += pane.studentNameSimple.getText();
+            content.append(pane.studentNameSimple.getText());
         }else{
-            content += StringUtils.removeAfterLastOccurrence(file.file.getName(), ".pdf").replaceAll(Pattern.quote(pane.studentNameReplace.getText()), pane.studentNameBy.getText());
+            content.append(StringUtils.removeAfterLastOccurrence(file.file.getName(), ".pdf").replaceAll(Pattern.quote(pane.studentNameReplace.getText()), pane.studentNameBy.getText()));
         }
         
         boolean hasOutOfColumn = false;
         for(GradeElement rating : file.grades){
             if(rating.isRoot() && rating.getOutOfTotal() > 0){ // Add outof column if needed.
                 hasOutOfColumn = true;
-                content += separator + (rating.getValue() == -1 ? "" :
+                content.append(separator).append(rating.getValue() == -1 ? "" :
                         decimalFormat.format(rating.getValue() / rating.getTotal() * rating.getOutOfTotal()));
             }
-            content += separator + (rating.getValue() == -1 ? "" : decimalFormat.format(rating.getValue()));
+            content.append(separator).append(rating.getValue() == -1 ? "" : decimalFormat.format(rating.getValue()));
         }
-        content += "\n";
+        content.append("\n");
         
         if(pane.settingsWithTxtElements.isSelected()){
             generateCommentsLines(file, hasOutOfColumn);
@@ -186,7 +186,7 @@ public class GradeExportRenderer {
     
     public void generateCommentsLines(ExportFile file, boolean hasOutOfColumn){
         
-        content += TR.tr("gradeTab.gradeExportWindow.csv.titles.comments");
+        content.append(TR.tr("gradeTab.gradeExportWindow.csv.titles.comments"));
         
         if(!file.comments.isEmpty()){
             
@@ -255,9 +255,9 @@ public class GradeExportRenderer {
             
             // Filling rows
             for(String line : rows){
-                content += (hasOutOfColumn ? separator : "") + line + "\n";
+                content.append(hasOutOfColumn ? separator : "").append(line).append("\n");
             }
-        }else content += "\n";
+        }else content.append("\n");
     }
     
     // OTHERS
@@ -333,13 +333,13 @@ public class GradeExportRenderer {
         file.createNewFile();
         BufferedWriter writer = new BufferedWriter(new FileWriter(file, false));
         
-        writer.write(content);
+        writer.write(String.valueOf(content));
         
         writer.flush();
         writer.close();
         
         exported++;
-        content = "";
+        content = new StringBuilder();
         return true;
     }
     

--- a/src/main/java/fr/clementgre/pdf4teachers/utils/TextWrapper.java
+++ b/src/main/java/fr/clementgre/pdf4teachers/utils/TextWrapper.java
@@ -128,14 +128,14 @@ public class TextWrapper {
     private String[] fillLineWithWord(String text){
         
         String[] splitted = text.split(" ", -1);
-        String line = splitted[0];
+        StringBuilder line = new StringBuilder(splitted[0]);
         
         for(int i = 1; i < splitted.length; i++){ // Remplis la ligne avec le maximum de mots puis renvoie la ligne
             
-            String lastLine = line;
-            line += " " + splitted[i];
+            String lastLine = String.valueOf(line);
+            line.append(" ").append(splitted[i]);
             
-            if(!test(line)){
+            if(!test(String.valueOf(line))){
                 StringBuilder remaining = new StringBuilder(splitted[i]);
                 for(i++; i < splitted.length; i++){ // Remplis la ligne avec le maximum de mots puis renvoie la ligne
                     remaining.append(" ").append(splitted[i]);
@@ -144,7 +144,7 @@ public class TextWrapper {
             }
         }
         
-        return new String[]{line, ""};
+        return new String[]{String.valueOf(line), ""};
     }
     
     private String[] fillLineWithChar(String word){


### PR DESCRIPTION
- Updated `SplitEngine` to use `StringBuilder` for constructing file paths.
- Updated `GradeCopyGradeScaleDialog` to use `StringBuilder` for building grade strings.
- Updated `GradeExportRenderer` to use `StringBuilder` for content generation.
- Updated `TextWrapper` to use `StringBuilder` for line filling methods.