### PR TITLE
Fix: Add Windows long path support for edition files (Fixes #173)

### DIFF
--- a/src/main/java/fr/clementgre/pdf4teachers/datasaving/Config.java
+++ b/src/main/java/fr/clementgre/pdf4teachers/datasaving/Config.java
@@ -6,6 +6,7 @@
 package fr.clementgre.pdf4teachers.datasaving;
 
 import fr.clementgre.pdf4teachers.interfaces.windows.log.Log;
+import fr.clementgre.pdf4teachers.utils.FilesUtils;
 import fr.clementgre.pdf4teachers.utils.MathUtils;
 import fr.clementgre.pdf4teachers.utils.StringUtils;
 import javafx.scene.paint.Color;
@@ -35,8 +36,9 @@ public class Config {
     }
     
     public Config(File file) throws IOException{
-        file.createNewFile();
-        this.file = file;
+        File safeFile = FilesUtils.toSafePath(file);
+        safeFile.createNewFile();
+        this.file = safeFile;
         setupYAML();
     }
     
@@ -57,7 +59,8 @@ public class Config {
     public void load() throws IOException{
         if(file == null) return;
         
-        InputStream input = new FileInputStream(file);
+        File safeFile = FilesUtils.toSafePath(file);
+        InputStream input = new FileInputStream(safeFile);
         base = yaml.load(input);
         input.close();
         
@@ -67,20 +70,23 @@ public class Config {
     
     public void save() throws IOException{
         if(file == null) return;
-        Writer output = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8);
+        File safeFile = FilesUtils.toSafePath(file);
+        Writer output = new OutputStreamWriter(new FileOutputStream(safeFile), StandardCharsets.UTF_8);
         yaml.dump(base, output);
         output.close();
     }
     
     public void saveTo(File file) throws IOException{
-        Writer output = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8);
+        File safeFile = FilesUtils.toSafePath(file);
+        Writer output = new OutputStreamWriter(new FileOutputStream(safeFile), StandardCharsets.UTF_8);
         yaml.dump(base, output);
         output.close();
     }
     
     public void saveToDestFile() throws IOException{
         if(destFile == null) return;
-        Writer output = new OutputStreamWriter(new FileOutputStream(destFile), StandardCharsets.UTF_8);
+        File safeFile = FilesUtils.toSafePath(destFile);
+        Writer output = new OutputStreamWriter(new FileOutputStream(safeFile), StandardCharsets.UTF_8);
         yaml.dump(base, output);
         output.close();
     }

--- a/src/main/java/fr/clementgre/pdf4teachers/document/editions/Edition.java
+++ b/src/main/java/fr/clementgre/pdf4teachers/document/editions/Edition.java
@@ -19,6 +19,7 @@ import fr.clementgre.pdf4teachers.panel.sidebar.grades.GradeTreeView;
 import fr.clementgre.pdf4teachers.panel.sidebar.skills.data.Notation;
 import fr.clementgre.pdf4teachers.panel.sidebar.skills.data.Skill;
 import fr.clementgre.pdf4teachers.panel.sidebar.skills.data.SkillsAssessment;
+import fr.clementgre.pdf4teachers.utils.FilesUtils;
 import fr.clementgre.pdf4teachers.utils.MathUtils;
 import fr.clementgre.pdf4teachers.utils.PlatformUtils;
 import fr.clementgre.pdf4teachers.utils.StringUtils;
@@ -413,7 +414,8 @@ public class Edition{
     public static File getEditFile(File pdfFile){
         String namePath = pdfFile.getParentFile().getAbsolutePath().replace(File.separator, "!E!").replace(":", "!P!");
         String nameName = pdfFile.getName() + ".yml";
-        return new File(Main.dataFolder + "editions" + File.separator + namePath + "!E!" + nameName);
+        File editFile = new File(Main.dataFolder + "editions" + File.separator + namePath + "!E!" + nameName);
+        return FilesUtils.toSafePath(editFile);
     }
     
     // get PDF file from YAML file

--- a/src/main/java/fr/clementgre/pdf4teachers/utils/FilesUtils.java
+++ b/src/main/java/fr/clementgre/pdf4teachers/utils/FilesUtils.java
@@ -23,6 +23,40 @@ import java.util.stream.Collectors;
 
 public final class FilesUtils {
     
+    /**
+     * Ensures the file path is compatible with the operating system's limitations.
+     * On Windows, if the path is longer than 200 characters, it prepends \\?\ to support long paths.
+     * On other platforms, returns the original file unchanged.
+     * 
+     * @param file The file to make safe for the current OS
+     * @return The file with OS-compatible path handling
+     */
+    public static File toSafePath(File file) {
+        if (!PlatformUtils.isWindows()) {
+            return file;
+        }
+        
+        String path = file.getAbsolutePath();
+        
+        // Already has long path prefix
+        if (path.startsWith("\\\\?\\")) {
+            return file;
+        }
+        
+        // Check if path needs long path support (approaching the limit)
+        // Use 200 as threshold to be safe (Windows limit is 260)
+        if (path.length() > 200) {
+            // Convert to long path format
+            if (!path.startsWith("\\\\")) {  // Not a UNC path
+                return new File("\\\\?\\" + path);
+            } else {  // UNC path: \\server\share -> \\?\UNC\server\share
+                return new File("\\\\?\\UNC\\" + path.substring(2));
+            }
+        }
+        
+        return file;
+    }
+    
     public static long getSize(Path path){
         try{
             if(Files.isRegularFile(path)){


### PR DESCRIPTION
## Summary
- Added OS-safe path handling to prevent Windows 260-character path limit errors
- Fixes #173 where edition saves fail with "Edition save() Can't save" error on long paths
- Automatically handles Windows long path format (\\?\) when paths exceed 200 characters

## Changes
1. **FilesUtils.java**: Added `toSafePath()` method that:
   - Returns file unchanged on Linux/Mac (no-op)
   - On Windows, adds `\\?\` prefix for paths >200 chars
   - Handles both regular and UNC paths correctly

2. **Config.java**: Updated all file operations to use safe paths:
   - Constructor, load(), save(), saveTo(), saveToDestFile()
   - Ensures YAML config files can be saved even in deep directories

3. **Edition.java**: Updated `getEditFile()` to return safe paths
   - Edition files now work with long paths on Windows

## Testing
- Method is cross-platform safe (no-op on non-Windows systems)
- Uses 200-char threshold (safe margin before Windows 260 limit)
- Preserves existing behavior for short paths

## Benefits
- Solves the long-standing issue reported in #173
- No breaking changes - transparent to existing code
- Future-proof: any new file operations can use `toSafePath()`

This fix allows teachers to organize their PDFs in deep folder structures without encountering save errors on Windows.