### PR TITLE
Fix: Replace libasound2t64 with libasound2 for Debian compatibility (Fixes #196)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -160,6 +160,7 @@ if(os.windows){
                         "mkdir -p ./AutoPackage/debian/DEBIAN ./AutoPackage/other/pdf4teachers ;" +
                         "dpkg-deb -x ./jpackage/pdf4teachers_" + version + "_amd64.deb ./AutoPackage/debian/ ;" +
                         "dpkg-deb -e ./jpackage/pdf4teachers_" + version + "_amd64.deb ./AutoPackage/debian/DEBIAN ;" +
+                        "sed -i 's/libasound2t64/libasound2/g' ./AutoPackage/debian/DEBIAN/control ;" +
                         "cp ../distribution/linux/PDF4Teachers.png ./AutoPackage/debian/opt/pdf4teachers/lib/PDF4Teachers.png ;" +
                         "cp ../distribution/linux/pdf4teachers.desktop ./AutoPackage/debian/opt/pdf4teachers/lib/pdf4teachers-PDF4Teachers.desktop ;" +
                         "dpkg-deb -Z xz -b ./AutoPackage/debian/ ./AutoPackage/PDF4Teachers-Linux-" + version + ".deb ;" +


### PR DESCRIPTION
## Summary
Fixes #196 by replacing the `libasound2t64` dependency with `libasound2` in the Debian package, ensuring compatibility with Debian stable and older Ubuntu versions.

## Problem
- PDF4Teachers 1.4.2+ requires `libasound2t64` which only exists in:
  - Debian testing/trixie (not stable)
  - Ubuntu 24.04+
- Users on Debian stable (bookworm) and older Ubuntu cannot install the .deb package
- Error: "Le paquet manquant est absent" (The missing package is absent)

## Solution
Added a `sed` command in the build process to replace `libasound2t64` with `libasound2` in the control file after jpackage creates it but before repackaging.

## Why This Works
- **Older systems** (Debian stable, Ubuntu <24.04): Have the actual `libasound2` package
- **Newer systems** (Debian testing, Ubuntu 24.04+): Provide `libasound2` as a virtual package via `libasound2t64`
- This ensures compatibility across all Debian/Ubuntu versions

## Testing
As confirmed by users in #196:
- Manual installation (.tar.gz) works on all systems
- Modified .deb with `libasound2` dependency works on Debian stable
- This fix automates what was manually tested and confirmed working

## Impact
- No functional changes to the application
- Only affects the Debian package dependencies
- Allows installation on a wider range of Linux distributions