### PR TITLE
Fix: Prevent PDF4Teachers from becoming default PDF viewer on Linux (Fixes #172)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -261,6 +261,7 @@ jlink {
             installerOptions += [
                     '--linux-menu-group', 'Education;Office',
                     '--linux-shortcut',
+                    '--resource-dir', 'distribution/linux/jpackage-resources',
                     //'--file-associations', 'distribution/linux/association-lin.properties'
             ]
             if (installerType == 'deb') installerOptions += ['--linux-deb-maintainer', 'clement.grennerat@clgr.io']

--- a/distribution/linux/jpackage-resources/postinst
+++ b/distribution/linux/jpackage-resources/postinst
@@ -1,0 +1,42 @@
+#!/bin/sh
+# postinst script for APPLICATION_PACKAGE
+#
+# see: dh_installdeb(1)
+
+set -e
+
+# summary of how this script can be called:
+#        * <postinst> `configure' <most-recently-configured-version>
+#        * <old-postinst> `abort-upgrade' <new version>
+#        * <conflictor's-postinst> `abort-remove' `in-favour' <package>
+#          <new-version>
+#        * <postinst> `abort-remove'
+#        * <deconfigured's-postinst> `abort-deconfigure' `in-favour'
+#          <failed-install-package> <version> `removing'
+#          <conflicting-package> <version>
+# for details, see https://www.debian.org/doc/debian-policy/ or
+# the debian-policy package
+
+case "$1" in
+    configure|abort-upgrade)
+        # Install desktop file with --novendor to prevent setting as default PDF viewer
+        if [ -x /usr/bin/xdg-desktop-menu ]; then
+            /usr/bin/xdg-desktop-menu install --novendor APPLICATION_DESKTOP_FILE || true
+        fi
+        
+        # Create symbolic link if needed
+        if [ "LAUNCHER_AS_SERVICE" = "true" ]; then
+            ln -sf APPLICATION_LAUNCHER_FILENAME /usr/bin/APPLICATION_PACKAGE
+        fi
+    ;;
+
+    abort-remove|abort-deconfigure)
+    ;;
+
+    *)
+        echo "postinst called with unknown argument \`$1'" >&2
+        exit 1
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
## Summary
Fixes #172 by preventing PDF4Teachers from automatically becoming the default PDF viewer on Debian/GNOME systems after installation.

## Problem
When installing PDF4Teachers on Debian with GNOME, it automatically replaces the system's default PDF viewer (usually Evince). This is problematic because:
- PDF4Teachers is a specialized tool for grading, not a general PDF viewer
- It lacks essential features like printing
- Users should explicitly choose to make it their default viewer

## Root Cause
The jpackage-generated `postinst` script uses:
```bash
xdg-desktop-menu install /opt/pdf4teachers/lib/pdf4teachers-PDF4Teachers.desktop
```
On GNOME systems, this can automatically set applications with `MimeType=application/pdf` as the default handler.

## Solution
Created a custom `postinst` template that adds the `--novendor` flag:
```bash
xdg-desktop-menu install --novendor /opt/pdf4teachers/lib/pdf4teachers-PDF4Teachers.desktop
```

## Implementation
1. Added `distribution/linux/jpackage-resources/postinst` with the custom template
2. Added `--resource-dir` option to jpackage configuration to use our custom resources
3. jpackage will use our postinst while keeping all other resources as default

## Benefits
- Clean solution using jpackage's built-in resource override mechanism
- PDF4Teachers still appears in "Open With" menu
- Users can manually set it as default if desired
- No automatic override of user's preferred PDF viewer

## Testing
The `--novendor` flag is documented to prevent vendor-specific behavior that can cause automatic default associations on some desktop environments.