### PR TITLE
Add Ctrl+B keyboard shortcut to toggle sidebar visibility

### DIFF
--- a/src/main/java/fr/clementgre/pdf4teachers/interfaces/KeyboardShortcuts.java
+++ b/src/main/java/fr/clementgre/pdf4teachers/interfaces/KeyboardShortcuts.java
@@ -102,6 +102,15 @@ public class KeyboardShortcuts {
         }));
         
         /******************************/
+        /**** Interface shortcuts *****/
+        /******************************/
+        shortcuts.add(new ShortcutRecord(TR.tr("shortcuts.interface.toggleSidebars"),
+                new KeyCodeCombination(KeyCode.B, KeyCodeCombination.SHORTCUT_DOWN), e -> {
+            SideBar.toggleSideBarsVisibility();
+            e.consume();
+        }));
+        
+        /******************************/
         /**** Navigation shortcuts ****/
         /******************************/
         //  +/- or arrows with shortcut for zoom and reset zoom

--- a/src/main/java/fr/clementgre/pdf4teachers/panel/sidebar/SideBar.java
+++ b/src/main/java/fr/clementgre/pdf4teachers/panel/sidebar/SideBar.java
@@ -290,4 +290,25 @@ public class SideBar extends TabPane {
         MainWindow.leftBar.loadTabsList(Main.syncUserData.leftBarOrganization);
         MainWindow.rightBar.loadTabsList(Main.syncUserData.rightBarOrganization);
     }
+    
+    public static void toggleSideBarsVisibility(){
+        MainWindow.leftBar.toggleVisibility();
+        MainWindow.rightBar.toggleVisibility();
+    }
+    
+    private boolean wasHidden = false;
+    
+    public void toggleVisibility(){
+        if(!getTabs().isEmpty()){
+            if(MainWindow.mainPane.getItems().contains(this)){
+                // Hide the sidebar
+                removeToPane();
+                wasHidden = true;
+            }else if(wasHidden){
+                // Show the sidebar
+                addToPane();
+                wasHidden = false;
+            }
+        }
+    }
 }

--- a/src/main/resources/translations/en_us.properties
+++ b/src/main/resources/translations/en_us.properties
@@ -711,6 +711,7 @@ shortcuts.elements.incrementSize=Increase the selected text element size, or the
 shortcuts.elements.newText=Add a new text element at cursor position
 shortcuts.elements.newVectorDrawing=Start a new vector drawing on the active page
 shortcuts.elements.selectNextGrade=Select the text field of the next grade to be entered
+shortcuts.interface.toggleSidebars=Toggle visibility of sidebars
 shortcuts.navigation.begin=Go to document's first page
 shortcuts.navigation.end=Go to document's last page
 shortcuts.navigation.fitWidth=Fit zoom to page width

--- a/src/main/resources/translations/fr_fr.properties
+++ b/src/main/resources/translations/fr_fr.properties
@@ -718,6 +718,7 @@ shortcuts.elements.incrementSize=Incrémenter la taille de l'élément textuel s
 shortcuts.elements.newText=Ajouter un nouvel élément textuel à l'emplacement du curseur
 shortcuts.elements.newVectorDrawing=Démarrer un nouveau dessin vectoriel sur la page courante
 shortcuts.elements.selectNextGrade=Sélectionne le champ de texte de la prochaine note à saisir
+shortcuts.interface.toggleSidebars=Afficher/masquer les panneaux latéraux
 shortcuts.navigation.begin=Aller à la première page du document
 shortcuts.navigation.end=Aller à la dernière page du document
 shortcuts.navigation.fitWidth=Adapter le zoom à la largeur de la page

--- a/src/main/resources/translations/it_it.properties
+++ b/src/main/resources/translations/it_it.properties
@@ -711,6 +711,7 @@ shortcuts.elements.incrementSize=Aumenta la dimensione dell'elemento di testo se
 shortcuts.elements.newText=Aggiungi un nuovo elemento di testo nella posizione del cursore
 shortcuts.elements.newVectorDrawing=Inizia un nuovo disegno vettoriale sulla pagina corrente
 shortcuts.elements.selectNextGrade=Seleziona il campo testo della successiva nota da inserire
+shortcuts.interface.toggleSidebars=Mostra/nascondi i pannelli laterali
 shortcuts.navigation.begin=Vai alla prima pagina del documento
 shortcuts.navigation.end=Vai all'ultima pagina del documento
 shortcuts.navigation.fitWidth=Adatta lo zoom alla larghezza della pagina


### PR DESCRIPTION
## Summary
This PR adds a keyboard shortcut (Ctrl+B / Cmd+B on Mac) to quickly toggle the visibility of both sidebars, addressing issue #206.

## Changes
- Implemented `toggleSideBarsVisibility()` static method in `SideBar.java` to toggle both sidebars
- Added `toggleVisibility()` instance method to handle individual sidebar toggling with proper state tracking
- Registered Ctrl+B (Cmd+B on Mac) shortcut in `KeyboardShortcuts.java`
- Added translation keys for the new shortcut in:
  - English: "Toggle visibility of sidebars"
  - French: "Afficher/masquer les panneaux latéraux"
  - Italian: "Mostra/nascondi i pannelli laterali"

## Notes
- The shortcut uses the platform-appropriate modifier (Ctrl on Windows/Linux, Cmd on Mac)
- Empty sidebars (no tabs) are not toggled to avoid confusion
- Documentation (ODT and PDF files) will need to be updated to include this new shortcut

Fixes #206