### PR TITLE
Restore scroll position when switching between documents

### DIFF
--- a/src/main/java/fr/clementgre/pdf4teachers/document/editions/Edition.java
+++ b/src/main/java/fr/clementgre/pdf4teachers/document/editions/Edition.java
@@ -45,7 +45,10 @@ public class Edition{
     private final File file;
     private final File editFile;
     private static final BooleanProperty isSave = new SimpleBooleanProperty(true);
-    
+
+    // Stores the scroll value loaded from the edit file (used to restore scroll position)
+    private double loadedScrollValue = 0;
+
     public Document document;
     
     public Edition(File file, Document document){
@@ -68,7 +71,10 @@ public class Edition{
             boolean upscaleGrid = versionID == 0; // Between 1.2.1 and 1.3.0, the grid size was multiplied by 100
             
             Double lastScrollValue = config.getDoubleNull("lastScrollValue");
-            if(lastScrollValue != null && updateScrollValue) document.setCurrentScrollValue(lastScrollValue);
+            if(lastScrollValue != null){
+                loadedScrollValue = lastScrollValue;
+                if(updateScrollValue) document.setCurrentScrollValue(lastScrollValue);
+            }
     
             loadItemsInPage(config.getSection("vectors").entrySet(), elementData -> {
                 VectorElement.readYAMLDataAndCreate(elementData.getValue(), elementData.getKey());
@@ -179,15 +185,17 @@ public class Edition{
         try{
             Config config = new Config(editFile);
             config.load();
-            
             config.base.put("lastScrollValue", document.getLastScrollValue());
-            
             config.save();
         }catch(Exception e){
             Log.eNotified(e);
         }
     }
-    
+
+    public double getLoadedScrollValue(){
+        return loadedScrollValue;
+    }
+
     private ArrayList<Object> getPageDataFromElements(ArrayList<Element> elements, Class<? extends Element> acceptedElements){
         ArrayList<Object> pageData = elements.stream()
                 .filter(acceptedElements::isInstance)

--- a/src/main/java/fr/clementgre/pdf4teachers/panel/MainScreen/MainScreen.java
+++ b/src/main/java/fr/clementgre/pdf4teachers/panel/MainScreen/MainScreen.java
@@ -584,19 +584,22 @@ public class MainScreen extends Pane {
             
             repaint();
             isRotating = false; // Can sometimes be kept to true
-            
+
+            // Get the scroll value loaded from the edition file (not from scrollbar which may be unreliable)
+            double scrollValue = document.edition.getLoadedScrollValue();
+
             // Zoom #2. If had opened file, keep same zoom factor.
             if(!hadOpenedFile){
                 if(MainWindow.userData.editPagesMode) zoomOperator.overviewWidth(true);
                 else zoomOperator.fitWidth(true, false);
             }else zoomOperator.zoom(oldPaneScale, true);
-            
+
             // Scroll position
             if(MainWindow.userData.editPagesMode){
                 PlatformUtils.runLaterOnUIThread(500, () -> zoomOperator.updatePaneDimensions(0, 0.5));
             }else{
-                double scrollValue = zoomOperator.vScrollBar.getValue(); // This value has been set when loading the edition
-                zoomOperator.updatePaneDimensions(scrollValue, 0.5);
+                final double finalScrollValue = scrollValue;
+                Platform.runLater(() -> zoomOperator.vScrollBar.setValue(finalScrollValue));
             }
             
             // Update menu bar


### PR DESCRIPTION
## Summary
- Fixed scroll position not being restored when switching between documents during a session
- The issue was that the scroll value read from the scrollbar was unreliable after zoom operations modified it
- Fixed by storing the scroll value directly when loading from the edit file, and reading from that stored value instead of the scrollbar

## Root Cause
When opening a document:
1. `loadEdition()` reads `lastScrollValue` from YAML and sets `vScrollBar.setValue()`
2. The subsequent zoom adjustment overwrites the scrollbar value
3. Original code read `vScrollBar.getValue()` after the zoom adjustment, getting the wrong value

## Solution
- Added `loadedScrollValue` field in `Edition.java` to store the scroll value when loaded from file
- Read from that stored value instead of the scrollbar in `MainScreen.java`
- Apply with `Platform.runLater()` to ensure UI is ready

## Test done
- [x] Open a PDF, add annotation, scroll to a position
- [x] Switch to another PDF
- [x] Switch back - scroll position is now restored correctly

Closes #215